### PR TITLE
Fixed bug in calculateTravelTime

### DIFF
--- a/geom/src/main/java/com/github/rinde/rinsim/geom/GeomHeuristics.java
+++ b/geom/src/main/java/com/github/rinde/rinsim/geom/GeomHeuristics.java
@@ -128,7 +128,7 @@ public final class GeomHeuristics {
         Measure<Double, Velocity> speed, Unit<Duration> outputTimeUnit) {
       final Measure<Double, Length> distance =
         Measure.valueOf(graph.connectionLength(from, to), distanceUnit);
-      return Math.min(doCalculateTravelTime(speed, distance, outputTimeUnit),
+      return Math.max(doCalculateTravelTime(speed, distance, outputTimeUnit),
         doCalculateTravelTime(
           Measure.valueOf(getSpeed(graph, from, to), speed.getUnit()), distance,
           outputTimeUnit));

--- a/geom/src/test/java/com/github/rinde/rinsim/geom/GraphsTest.java
+++ b/geom/src/test/java/com/github/rinde/rinsim/geom/GraphsTest.java
@@ -120,6 +120,30 @@ public class GraphsTest {
       prevPath = newPath;
     }
   }
+  
+  @Test
+  public void fastestPathSpeedLimitationTest() {
+      final Graph<MultiAttributeData> attributeGraph =
+        new TableGraph<>();
+      Point A, B, C;
+      A = new Point(0, 0);
+      B = new Point(0, 1);
+      C = new Point(1, 0);
+      attributeGraph.addConnection(A, B,
+        MultiAttributeData.builder().setMaxSpeed(1).build());
+      attributeGraph.addConnection(A, C,
+        MultiAttributeData.builder().setMaxSpeed(3).build());
+      final GeomHeuristic heuristic = GeomHeuristics.time(0d);
+
+      assertEquals(1d,
+        heuristic.calculateTravelTime(attributeGraph, A, B, SI.KILOMETER,
+          Measure.valueOf(2d, NonSI.KILOMETERS_PER_HOUR), NonSI.HOUR),
+        DELTA);
+      assertEquals(0.5d,
+        heuristic.calculateTravelTime(attributeGraph, A, C, SI.KILOMETER,
+          Measure.valueOf(2d, NonSI.KILOMETERS_PER_HOUR), NonSI.HOUR),
+        DELTA);
+    }
 
   /**
    * The shortest path changes based on the connection data.

--- a/geom/src/test/java/com/github/rinde/rinsim/geom/GraphsTest.java
+++ b/geom/src/test/java/com/github/rinde/rinsim/geom/GraphsTest.java
@@ -30,6 +30,9 @@ import java.util.Collection;
 import java.util.List;
 
 import javax.annotation.Nullable;
+import javax.measure.Measure;
+import javax.measure.unit.NonSI;
+import javax.measure.unit.SI;
 
 import org.apache.commons.math3.random.MersenneTwister;
 import org.apache.commons.math3.random.RandomGenerator;


### PR DESCRIPTION
Originally, this method calculated the minimal speed. But since it now calculates the travel time, it should take the maximum time (the time a vehicle needs to drive along a path with the minimum of the speed of the road and the speed of the vehicle) of both calculations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rinde/rinsim/42)
<!-- Reviewable:end -->
