### PR TITLE
BlockingGraphRoadModel misses providing type - add GraphRoadModel.class to its builder

### DIFF
--- a/example/src/main/java/com/github/rinde/rinsim/examples/demo/factory/BlockingGraphRoadModel.java
+++ b/example/src/main/java/com/github/rinde/rinsim/examples/demo/factory/BlockingGraphRoadModel.java
@@ -29,6 +29,7 @@ import javax.measure.quantity.Velocity;
 import javax.measure.unit.Unit;
 
 import com.github.rinde.rinsim.core.model.DependencyProvider;
+import com.github.rinde.rinsim.core.model.road.GraphRoadModel;
 import com.github.rinde.rinsim.core.model.road.GraphRoadModelImpl;
 import com.github.rinde.rinsim.core.model.road.MoveProgress;
 import com.github.rinde.rinsim.core.model.road.MovingRoadUser;
@@ -110,7 +111,7 @@ public class BlockingGraphRoadModel extends GraphRoadModelImpl {
     private static final long serialVersionUID = -8663781587611642451L;
 
     Builder() {
-      setProvidingTypes(RoadModel.class, GraphRoadModelImpl.class,
+      setProvidingTypes(RoadModel.class, GraphRoadModelImpl.class, GraphRoadModel.class,
         BlockingGraphRoadModel.class);
     }
 


### PR DESCRIPTION
BlockingGraphRoadModel could not satisfy the dependency of GraphRoadModel, which it should be able to since its an implementation of it. Solution: GraphRoadModel has been added as a providing type in the builder of BlockingGraphRoadModel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rinde/rinsim/43)
<!-- Reviewable:end -->
