### PR TITLE
[Thesis] Heuristic Based Movement of RouteFollowingVehicles

### DIFF
--- a/central/src/main/java/com/github/rinde/rinsim/central/rt/RtCentral.java
+++ b/central/src/main/java/com/github/rinde/rinsim/central/rt/RtCentral.java
@@ -51,6 +51,7 @@ import com.github.rinde.rinsim.core.model.time.TimeLapse;
 import com.github.rinde.rinsim.event.Event;
 import com.github.rinde.rinsim.event.Listener;
 import com.github.rinde.rinsim.experiment.MASConfiguration;
+import com.github.rinde.rinsim.geom.GeomHeuristic;
 import com.github.rinde.rinsim.pdptw.common.AddVehicleEvent;
 import com.github.rinde.rinsim.pdptw.common.PDPRoadModel;
 import com.github.rinde.rinsim.pdptw.common.RouteFollowingVehicle;
@@ -160,6 +161,11 @@ public final class RtCentral {
 
   public static TimedEventHandler<AddVehicleEvent> vehicleHandler() {
     return VehicleCreator.INSTANCE;
+  }
+
+  public static TimedEventHandler<AddVehicleEvent> vehicleHandler(
+      GeomHeuristic heuristic) {
+    return new HeuristicVehicleCreator(heuristic);
   }
 
   enum Options {
@@ -297,6 +303,28 @@ public final class RtCentral {
       public String toString() {
         return Central.class.getName() + ".vehicleHandler()";
       }
+    };
+
+  }
+
+  static class HeuristicVehicleCreator
+      implements TimedEventHandler<AddVehicleEvent>, Serializable {
+
+    static GeomHeuristic heuristic;
+
+    HeuristicVehicleCreator(GeomHeuristic h) {
+      heuristic = h;
+    }
+
+    @Override
+    public void handleTimedEvent(AddVehicleEvent event, SimulatorAPI sim) {
+      sim.register(new RouteFollowingVehicle(event.getVehicleDTO(), true,
+        RouteFollowingVehicle.nopAdjuster(), heuristic));
+    }
+
+    @Override
+    public String toString() {
+      return Central.class.getName() + ".vehicleHandler()";
     }
   }
 

--- a/central/src/main/java/com/github/rinde/rinsim/central/rt/RtCentral.java
+++ b/central/src/main/java/com/github/rinde/rinsim/central/rt/RtCentral.java
@@ -324,7 +324,8 @@ public final class RtCentral {
 
     @Override
     public String toString() {
-      return Central.class.getName() + ".vehicleHandler()";
+      return Central.class.getName() + ".vehicleHandler(" + heuristic.toString()
+        + ")";
     }
   }
 

--- a/core/src/main/java/com/github/rinde/rinsim/core/model/road/ForwardingRoadModel.java
+++ b/core/src/main/java/com/github/rinde/rinsim/core/model/road/ForwardingRoadModel.java
@@ -100,6 +100,18 @@ public class ForwardingRoadModel<T extends GenericRoadModel>
   }
 
   @Override
+  public MoveProgress moveTo(MovingRoadUser object, RoadUser destination,
+      TimeLapse time, GeomHeuristic heuristic) {
+    return delegate().moveTo(object, destination, time, heuristic);
+  }
+
+  @Override
+  public MoveProgress moveTo(MovingRoadUser object, Point destination,
+      TimeLapse time, GeomHeuristic heuristic) {
+    return delegate().moveTo(object, destination, time, heuristic);
+  }
+
+  @Override
   public MoveProgress followPath(MovingRoadUser object, Queue<Point> path,
       TimeLapse time) {
     return delegate().followPath(object, path, time);
@@ -206,6 +218,14 @@ public class ForwardingRoadModel<T extends GenericRoadModel>
   public RoadPath getPathTo(Point from, Point to, Unit<Duration> timeUnit,
       Measure<Double, Velocity> speed, GeomHeuristic heuristic) {
     return delegate().getPathTo(from, to, timeUnit, speed, heuristic);
+  }
+
+  @Override
+  public RoadPath getPathTo(MovingRoadUser object, Point destination,
+      Unit<Duration> timeUnit, Measure<Double, Velocity> maxSpeed,
+      GeomHeuristic heuristic) {
+    return delegate().getPathTo(object, destination, timeUnit, maxSpeed,
+      heuristic);
   }
 
   @Override

--- a/core/src/main/java/com/github/rinde/rinsim/core/model/road/GraphRoadModelSnapshot.java
+++ b/core/src/main/java/com/github/rinde/rinsim/core/model/road/GraphRoadModelSnapshot.java
@@ -27,8 +27,8 @@ import javax.measure.quantity.Velocity;
 import javax.measure.unit.Unit;
 
 import com.github.rinde.rinsim.geom.ConnectionData;
-import com.github.rinde.rinsim.geom.Graphs;
 import com.github.rinde.rinsim.geom.GeomHeuristic;
+import com.github.rinde.rinsim.geom.Graphs;
 import com.github.rinde.rinsim.geom.ImmutableGraph;
 import com.github.rinde.rinsim.geom.Point;
 import com.google.auto.value.AutoValue;

--- a/core/src/main/java/com/github/rinde/rinsim/core/model/road/PlaneRoadModel.java
+++ b/core/src/main/java/com/github/rinde/rinsim/core/model/road/PlaneRoadModel.java
@@ -40,8 +40,8 @@ import com.github.rinde.rinsim.core.model.time.TimeLapse;
 import com.github.rinde.rinsim.geom.AbstractGraph;
 import com.github.rinde.rinsim.geom.Connection;
 import com.github.rinde.rinsim.geom.ConnectionData;
-import com.github.rinde.rinsim.geom.Graphs;
 import com.github.rinde.rinsim.geom.GeomHeuristic;
+import com.github.rinde.rinsim.geom.Graphs;
 import com.github.rinde.rinsim.geom.Point;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
@@ -205,6 +205,14 @@ public class PlaneRoadModel extends AbstractRoadModel<Point> {
       heuristic.calculateCost(planeGraph, from, to),
       heuristic.calculateTravelTime(planeGraph, from, to, getDistanceUnit(),
         speed, timeUnit));
+  }
+
+  @Override
+  public RoadPath getPathTo(MovingRoadUser object, Point destination,
+      Unit<Duration> timeUnit, Measure<Double, Velocity> speed,
+      GeomHeuristic heuristic) {
+    return getPathTo(getPosition(object), destination, timeUnit, speed,
+      heuristic);
   }
 
   @Override

--- a/core/src/main/java/com/github/rinde/rinsim/core/model/road/RoadModel.java
+++ b/core/src/main/java/com/github/rinde/rinsim/core/model/road/RoadModel.java
@@ -126,6 +126,82 @@ public interface RoadModel extends Model<RoadUser> {
       TimeLapse time);
 
   /**
+   * Moves the specified {@link MovingRoadUser} towards the specified
+   * <code>destination</code> using the path returned by
+   * {@link #getPathTo(Point, Point, Unit, Measure, GeomHeuristic)}. There must
+   * be time left in the provided {@link TimeLapse}. The
+   * {@link #getDestination(MovingRoadUser)} method will return the destination
+   * point as specified in the most recent invocation of this method.
+   * <p>
+   * <b>Speed</b><br>
+   * The {@link MovingRoadUser} has to define a speed with which it wants to
+   * travel. This method uses the {@link MovingRoadUser}s speed as an
+   * <i>upper</i> bound, it gives no guarantee about the lower bound (i.e. the
+   * object could stand still). The actual speed of the object depends on the
+   * model implementation. A model can define constraints such as speed limits
+   * or traffic jams which can slow down a {@link MovingRoadUser}.
+   * <p>
+   * <b>Time</b><br>
+   * The time that is specified as indicated by the {@link TimeLapse} object may
+   * or may not be consumed completely. Normally, this method will try to
+   * consume all time in the {@link TimeLapse} object. In case the destination
+   * is reached before all time is consumed (which depends on the object's
+   * <i>speed</i>, the distance to the <code>destination</code> and any speed
+   * constraints if available) there will be some time left in the
+   * {@link TimeLapse}.
+   * @param object The object that is moved.
+   * @param destination The destination position.
+   * @param time The time that is available for travel.
+   * @param heuristic The heuristic to use for path resolution.
+   * @return A {@link MoveProgress} instance which details: the distance
+   *         travelled, the actual time spent travelling and the nodes which
+   *         where travelled.
+   * @see #moveTo(MovingRoadUser, Point, TimeLapse)
+   * @see #followPath(MovingRoadUser, Queue, TimeLapse)
+   */
+  MoveProgress moveTo(MovingRoadUser object, RoadUser destination,
+      TimeLapse time,
+      GeomHeuristic heuristic);
+
+  /**
+   * Moves the specified {@link MovingRoadUser} towards the specified
+   * <code>destination</code> using the path returned by
+   * {@link #getPathTo(Point, Point, Unit, Measure, GeomHeuristic)}. There must
+   * be time left in the provided {@link TimeLapse}. The
+   * {@link #getDestination(MovingRoadUser)} method will return the destination
+   * point as specified in the most recent invocation of this method.
+   * <p>
+   * <b>Speed</b><br>
+   * The {@link MovingRoadUser} has to define a speed with which it wants to
+   * travel. This method uses the {@link MovingRoadUser}s speed as an
+   * <i>upper</i> bound, it gives no guarantee about the lower bound (i.e. the
+   * object could stand still). The actual speed of the object depends on the
+   * model implementation. A model can define constraints such as speed limits
+   * or traffic jams which can slow down a {@link MovingRoadUser}.
+   * <p>
+   * <b>Time</b><br>
+   * The time that is specified as indicated by the {@link TimeLapse} object may
+   * or may not be consumed completely. Normally, this method will try to
+   * consume all time in the {@link TimeLapse} object. In case the destination
+   * is reached before all time is consumed (which depends on the object's
+   * <i>speed</i>, the distance to the <code>destination</code> and any speed
+   * constraints if available) there will be some time left in the
+   * {@link TimeLapse}.
+   * @param object The object that is moved.
+   * @param destination The destination position.
+   * @param time The time that is available for travel.
+   * @param heuristic The heuristic to use for path resolution.
+   * @return A {@link MoveProgress} instance which details: the distance
+   *         travelled, the actual time spent travelling and the nodes which
+   *         where travelled.
+   * @see #moveTo(MovingRoadUser, RoadUser, TimeLapse)
+   * @see #followPath(MovingRoadUser, Queue, TimeLapse)
+   */
+  MoveProgress moveTo(MovingRoadUser object, Point destination,
+      TimeLapse time,
+      GeomHeuristic heuristic);
+
+  /**
    * Moves the specified {@link MovingRoadUser} using the specified path and
    * with the specified time. The provided <code>path</code> can not be empty
    * and there must be time left in the provided {@link TimeLapse}.
@@ -369,6 +445,23 @@ public interface RoadModel extends Model<RoadUser> {
       Measure<Double, Velocity> maxSpeed, GeomHeuristic heuristic);
 
   /**
+   * Finds a path that is optimal according to the given {@link GeomHeuristic}
+   * between current position of the <code>object</code> and its destination at
+   * point <code>destination</code>.
+   * @param object The road user.
+   * @param destination The ending point.
+   * @param timeUnit The time unit to use for the calculations.
+   * @param maxSpeed The speed of the {@link RoadUser} that requests the path.
+   * @param heuristic The heuristic to use to determine the optimal path.
+   * @return The path following the heuristic decorated with the heuristic value
+   *         for the path as well as its travel time with the given speed in the
+   *         given time unit.
+   */
+  RoadPath getPathTo(MovingRoadUser object, Point destination,
+      Unit<Duration> timeUnit, Measure<Double, Velocity> maxSpeed,
+      GeomHeuristic heuristic);
+
+  /**
    * Determines the distance of the given path, indicated by a list of
    * connecting points.
    * @param path The path to find the distance of.
@@ -404,4 +497,5 @@ public interface RoadModel extends Model<RoadUser> {
    * @return A snapshot of the current state of this road model.
    */
   RoadModelSnapshot getSnapshot();
+
 }

--- a/core/src/test/java/com/github/rinde/rinsim/core/model/road/AbstractRoadModelTest.java
+++ b/core/src/test/java/com/github/rinde/rinsim/core/model/road/AbstractRoadModelTest.java
@@ -93,10 +93,10 @@ public abstract class AbstractRoadModelTest<T extends GenericRoadModel> {
   protected final double EPSILON = 0.02;
 
   protected T model;
-  protected Point SW;
-  protected Point SE;
-  protected Point NE;
-  protected Point NW;
+  protected static Point SW = new Point(0, 0);;
+  protected static Point SE = new Point(10, 0);
+  protected static Point NE = new Point(10, 10);
+  protected static Point NW = new Point(0, 10);
 
   /**
    * must instantiate model and points
@@ -104,10 +104,10 @@ public abstract class AbstractRoadModelTest<T extends GenericRoadModel> {
    */
   @Before
   public void setUpPoints() throws Exception {
-    SW = new Point(0, 0);
-    SE = new Point(10, 0);
-    NE = new Point(10, 10);
-    NW = new Point(0, 10);
+    // SW = new Point(0, 0);
+    // SE = new Point(10, 0);
+    // NE = new Point(10, 10);
+    // NW = new Point(0, 10);
     doSetUp();
   }
 

--- a/geom/src/main/java/com/github/rinde/rinsim/geom/TableGraph.java
+++ b/geom/src/main/java/com/github/rinde/rinsim/geom/TableGraph.java
@@ -29,6 +29,7 @@ import javax.annotation.Nullable;
 import com.google.common.base.Optional;
 import com.google.common.base.Supplier;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableTable;
 import com.google.common.collect.Table;
 import com.google.common.collect.Tables;
 
@@ -50,6 +51,17 @@ public class TableGraph<E extends ConnectionData> extends AbstractGraph<E> {
     data = Tables.newCustomTable(
       new LinkedHashMap<Point, Map<Point, Connection<E>>>(),
       new LinkedHashMapFactory<Connection<E>>());
+  }
+
+  /**
+   * Create a new graph with initial data.
+   * @param table The table that is copied into the graph.
+   */
+  public TableGraph(Table<Point, Point, Connection<E>> table) {
+    data = Tables.newCustomTable(
+      new LinkedHashMap<Point, Map<Point, Connection<E>>>(),
+      new LinkedHashMapFactory<Connection<E>>());
+    data.putAll(table);
   }
 
   @Override
@@ -164,14 +176,34 @@ public class TableGraph<E extends ConnectionData> extends AbstractGraph<E> {
     return new TableGraphSupplier<>();
   }
 
+  /**
+   * Instantiates a new graph supplier that will create {@link TableGraph}
+   * instances using the specified data.
+   * @param data The table that is copied into this new graph.
+   * @param <E> The type of connection data.
+   * @return A new supplier.
+   */
+  public static <E extends ConnectionData> Supplier<TableGraph<E>> supplier(
+      ImmutableTable<Point, Point, Connection<E>> data) {
+    return new TableGraphSupplier<>(data);
+  }
+
   private static class TableGraphSupplier<E extends ConnectionData>
       implements Supplier<TableGraph<E>> {
 
-    TableGraphSupplier() {}
+    private final ImmutableTable<Point, Point, Connection<E>> data;
+
+    TableGraphSupplier() {
+      this(ImmutableTable.<Point, Point, Connection<E>>of());
+    }
+
+    TableGraphSupplier(ImmutableTable<Point, Point, Connection<E>> d) {
+      data = d;
+    }
 
     @Override
     public TableGraph<E> get() {
-      return new TableGraph<>();
+      return new TableGraph<>(data);
     }
 
     @Override

--- a/pdptw/src/main/java/com/github/rinde/rinsim/pdptw/common/PDPRoadModel.java
+++ b/pdptw/src/main/java/com/github/rinde/rinsim/pdptw/common/PDPRoadModel.java
@@ -41,6 +41,8 @@ import com.github.rinde.rinsim.core.model.road.MovingRoadUser;
 import com.github.rinde.rinsim.core.model.road.RoadModel;
 import com.github.rinde.rinsim.core.model.road.RoadUser;
 import com.github.rinde.rinsim.core.model.time.TimeLapse;
+import com.github.rinde.rinsim.geom.GeomHeuristic;
+import com.github.rinde.rinsim.geom.GeomHeuristics;
 import com.github.rinde.rinsim.geom.Point;
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Joiner;
@@ -155,6 +157,13 @@ public class PDPRoadModel extends ForwardingRoadModel<GenericRoadModel>
   @Override
   public MoveProgress moveTo(MovingRoadUser object,
       RoadUser destinationRoadUser, TimeLapse time) {
+    return moveTo(object, destinationRoadUser, time,
+      GeomHeuristics.euclidean());
+  }
+
+  @Override
+  public MoveProgress moveTo(MovingRoadUser object,
+      RoadUser destinationRoadUser, TimeLapse time, GeomHeuristic heuristic) {
     final DestinationObject newDestinationObject;
     if (destinationRoadUser instanceof Parcel) {
       final Parcel dp = (Parcel) destinationRoadUser;
@@ -230,7 +239,8 @@ public class PDPRoadModel extends ForwardingRoadModel<GenericRoadModel>
         newDestinationObject.roadUser());
       destinationHistory.put(object, newDestinationObject);
     }
-    return delegate().moveTo(object, newDestinationObject.dest(), time);
+    return delegate().moveTo(object, newDestinationObject.dest(), time,
+      heuristic);
   }
 
   /**

--- a/pdptw/src/main/java/com/github/rinde/rinsim/pdptw/common/RouteFollowingVehicle.java
+++ b/pdptw/src/main/java/com/github/rinde/rinsim/pdptw/common/RouteFollowingVehicle.java
@@ -31,7 +31,6 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import javax.measure.Measure;
 import javax.measure.quantity.Duration;
-import javax.measure.quantity.Length;
 import javax.measure.quantity.Velocity;
 import javax.measure.unit.Unit;
 
@@ -46,7 +45,6 @@ import com.github.rinde.rinsim.core.model.pdp.Parcel;
 import com.github.rinde.rinsim.core.model.pdp.Vehicle;
 import com.github.rinde.rinsim.core.model.pdp.VehicleDTO;
 import com.github.rinde.rinsim.core.model.road.RoadModel;
-import com.github.rinde.rinsim.core.model.road.RoadModels;
 import com.github.rinde.rinsim.core.model.time.TimeLapse;
 import com.github.rinde.rinsim.event.Event;
 import com.github.rinde.rinsim.event.Listener;
@@ -54,6 +52,8 @@ import com.github.rinde.rinsim.fsm.AbstractState;
 import com.github.rinde.rinsim.fsm.StateMachine;
 import com.github.rinde.rinsim.fsm.StateMachine.StateMachineEvent;
 import com.github.rinde.rinsim.fsm.StateMachine.StateTransitionEvent;
+import com.github.rinde.rinsim.geom.GeomHeuristic;
+import com.github.rinde.rinsim.geom.GeomHeuristics;
 import com.github.rinde.rinsim.geom.Point;
 import com.google.common.base.Optional;
 import com.google.common.collect.Iterables;
@@ -118,6 +118,7 @@ public class RouteFollowingVehicle extends Vehicle {
   Optional<Depot> depot;
   Optional<TimeLapse> currentTime;
   boolean isDiversionAllowed;
+  GeomHeuristic routeHeuristic;
 
   private Optional<Measure<Double, Velocity>> speed;
   private final boolean allowDelayedRouteChanges;
@@ -141,6 +142,22 @@ public class RouteFollowingVehicle extends Vehicle {
    *          {@link #setRoute(Iterable)} method.
    * @param adjuster Allows to set a route adjuster to 'fix' routes if
    *          necessary.
+   * @param heuristic The {@link GeomHeuristic} to decide optimal routes.
+   */
+  public RouteFollowingVehicle(VehicleDTO dto,
+      boolean allowDelayedRouteChanging, RouteAdjuster adjuster,
+      GeomHeuristic heuristic) {
+    this(dto, allowDelayedRouteChanging, adjuster);
+    routeHeuristic = heuristic;
+  }
+
+  /**
+   * Initializes the vehicle.
+   * @param dto The {@link VehicleDTO} that defines this vehicle.
+   * @param allowDelayedRouteChanging This boolean changes the behavior of the
+   *          {@link #setRoute(Iterable)} method.
+   * @param adjuster Allows to set a route adjuster to 'fix' routes if
+   *          necessary.
    */
   public RouteFollowingVehicle(VehicleDTO dto,
       boolean allowDelayedRouteChanging, RouteAdjuster adjuster) {
@@ -152,6 +169,7 @@ public class RouteFollowingVehicle extends Vehicle {
     currentTime = Optional.absent();
     allowDelayedRouteChanges = allowDelayedRouteChanging;
     routeAdjuster = adjuster;
+    routeHeuristic = GeomHeuristics.euclidean();
 
     stateMachine = createStateMachine();
     waitState = stateMachine.getStateOfType(Wait.class);
@@ -399,12 +417,9 @@ public class RouteFollowingVehicle extends Vehicle {
    * @return The travel time in the used time unit.
    */
   protected long computeTravelTimeTo(Point p, Unit<Duration> timeUnit) {
-    final Measure<Double, Length> distance = Measure.valueOf(Point.distance(
-      getRoadModel().getPosition(this), p), getRoadModel()
-        .getDistanceUnit());
-
     return DoubleMath.roundToLong(
-      RoadModels.computeTravelTime(speed.get(), distance, timeUnit),
+      getRoadModel().getPathTo(this, p, timeUnit,
+        speed.get(), routeHeuristic).getTravelTime(),
       RoundingMode.CEILING);
   }
 
@@ -675,7 +690,9 @@ public class RouteFollowingVehicle extends Vehicle {
       if (getRoadModel().equalPosition(context, cur)) {
         return DefaultEvent.ARRIVED;
       }
-      getRoadModel().moveTo(context, cur, currentTime.get());
+      getRoadModel().moveTo(context, cur,
+        currentTime.get(),
+        context.routeHeuristic);
       if (getRoadModel().equalPosition(context, cur)
         && currentTime.get().hasTimeLeft()) {
         return DefaultEvent.ARRIVED;


### PR DESCRIPTION
As discovered by @christofluyten, the `RouteFollowingVehicle` class was still untouched after the changes made for RinSim version 4.4.0 and 4.4.1. This resulted in the vehicles correctly computing costs, but still travelling along the euclidean path.

The following PR addresses this issue by adding support for new `moveTo` methods utilizing the `GeomHeuristic`. Variants which takes `MovingRoadUser` instead of `Point` also exist to handle vehicles on a `Connection`.

Additional test cases have been added in RinSim and RinLog to verify this issue. The structure of `configs` in the RinSim tests `GraphRoadModelTest` has been modified to create consistency with the tests and the snapshots of the road models used by the tests.

An accompanied RinLog PR will allow the Truck to be configured with a `GeomHeuristic`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rinde/rinsim/48)
<!-- Reviewable:end -->
